### PR TITLE
Fix: Image not loading on aboutme page in production

### DIFF
--- a/src/pages/aboutme.astro
+++ b/src/pages/aboutme.astro
@@ -1,6 +1,7 @@
 ---
 import MainContainer from "src/components/MainContainer.astro";
 import Layout from "../components/Layout.astro";
+import avatarImage from "../images/avatar.jpeg";
 
 ---
 
@@ -9,7 +10,7 @@ import Layout from "../components/Layout.astro";
     <div class="flex flex-col md:flex-row items-center space-x-4 shadow-box-up dark:shadow-orange-dark p-4 md:p-6 rounded-xl">
       <img
         class="p-1 mb-2 md:mb-0 w-40 h-40 rounded-full ring-2 ring-gray-300 dark:ring-gray-500"
-        src="/src/images/avatar.jpeg"
+        src={avatarImage.src}
         alt="Bordered avatar"
       />
       <div class="font-medium dark:text-white">


### PR DESCRIPTION
## Summary
- Fixed avatar image not displaying on the /aboutme page when deployed to Vercel
- Changed from direct path reference to proper ES module import

## Problem
The avatar image was referenced using `/src/images/avatar.jpeg` which works locally but fails in production because:
- The `/src` directory is not publicly accessible in production builds
- Astro needs to process and bundle images during build time

## Solution
Updated the image handling to use Astro's recommended approach:
1. Import the image as an ES module: `import avatarImage from "../images/avatar.jpeg"`
2. Reference it using the imported object: `src={avatarImage.src}`

This ensures the image is properly processed by Astro's build system and will be available in the production deployment.

## Test plan
- [ ] Build the project locally: `npm run build`
- [ ] Preview the production build: `npm run preview`
- [ ] Navigate to `/aboutme` and verify the avatar image loads
- [ ] Deploy to Vercel and confirm image loads on production URL